### PR TITLE
Wait us updates

### DIFF
--- a/model/CircuitPlayground.cpp
+++ b/model/CircuitPlayground.cpp
@@ -73,8 +73,6 @@ CircuitPlayground::CircuitPlayground() :
     // Bring up fiber scheduler.
     scheduler_init(messageBus);
 
-    system_timer_calibrate_cycles();
-
     messageBus.listen(DEVICE_ID_MESSAGE_BUS_LISTENER, DEVICE_EVT_ANY, this, &CircuitPlayground::onListenerRegisteredEvent);
 
     for(int i = 0; i < DEVICE_COMPONENT_COUNT; i++)

--- a/model/CircuitPlayground.cpp
+++ b/model/CircuitPlayground.cpp
@@ -73,6 +73,8 @@ CircuitPlayground::CircuitPlayground() :
     // Bring up fiber scheduler.
     scheduler_init(messageBus);
 
+    system_timer_calibrate_cycles();
+
     messageBus.listen(DEVICE_ID_MESSAGE_BUS_LISTENER, DEVICE_EVT_ANY, this, &CircuitPlayground::onListenerRegisteredEvent);
 
     for(int i = 0; i < DEVICE_COMPONENT_COUNT; i++)
@@ -80,6 +82,7 @@ CircuitPlayground::CircuitPlayground() :
         if(CodalComponent::components[i])
             CodalComponent::components[i]->init();
     }
+
 
     //
     // Device specific configuraiton

--- a/source/codal_target_hal.cpp
+++ b/source/codal_target_hal.cpp
@@ -53,21 +53,11 @@ int target_random(int max)
 
 void target_wait_us(unsigned long us)
 {
-    if (us == 0)
+    if (us <= 1)
         return;
 
-    if (us < 3)
-        us = 3;
-
-    uint32_t n = (uint32_t)(us - 3) * (CODAL_CPU_CLOCK_SPEED / 1000000) / 3;
-    __asm__ __volatile__(
-        "1:              \n"
-        "   sub %0, #1   \n" // subtract 1 from %0 (n)
-        "   bne 1b       \n" // if result is not 0 jump to 1
-        : "+r" (n)           // '%0' is n variable with RW constraints
-        :                    // no input
-        :                    // no clobber
-    );
+    // for loop in system_timer_wait_cycles + plus multiply of us takes around 2 us.
+    codal::system_timer_wait_cycles(10 * (us- 2));
 }
 
 void target_wait(uint32_t milliseconds)

--- a/source/codal_target_hal.cpp
+++ b/source/codal_target_hal.cpp
@@ -51,7 +51,7 @@ int target_random(int max)
     return codal::random(max);
 }
 
-void target_wait_us(unsigned long us)
+void target_wait_us(uint32_t us)
 {
     codal::system_timer_wait_us(us);
 }

--- a/source/codal_target_hal.cpp
+++ b/source/codal_target_hal.cpp
@@ -51,8 +51,23 @@ int target_random(int max)
     return codal::random(max);
 }
 
-void target_wait_us(unsigned long us) {
-    codal::system_timer_wait_us(us);
+void target_wait_us(unsigned long us)
+{
+    if (us == 0)
+        return;
+
+    if (us < 3)
+        us = 3;
+
+    uint32_t n = (uint32_t)(us - 3) * (CODAL_CPU_CLOCK_SPEED / 1000000) / 3;
+    __asm__ __volatile__(
+        "1:              \n"
+        "   sub %0, #1   \n" // subtract 1 from %0 (n)
+        "   bne 1b       \n" // if result is not 0 jump to 1
+        : "+r" (n)           // '%0' is n variable with RW constraints
+        :                    // no input
+        :                    // no clobber
+    );
 }
 
 void target_wait(uint32_t milliseconds)

--- a/source/codal_target_hal.cpp
+++ b/source/codal_target_hal.cpp
@@ -53,11 +53,7 @@ int target_random(int max)
 
 void target_wait_us(unsigned long us)
 {
-    if (us <= 1)
-        return;
-
-    // for loop in system_timer_wait_cycles + plus multiply of us takes around 2 us.
-    codal::system_timer_wait_cycles(10 * (us- 2));
+    codal::system_timer_wait_us(us);
 }
 
 void target_wait(uint32_t milliseconds)
@@ -69,6 +65,7 @@ void target_reset()
 {
     NVIC_SystemReset();
 }
+
 // 128 bits starting from here...
 uint32_t* const serial_start = (uint32_t *)0x0080A00C;
 uint32_t target_get_serial()
@@ -85,13 +82,6 @@ void target_panic(int statusCode)
     DMESG("*** CODAL PANIC : [%d]", statusCode);
     while (1)
     {
-    }
-#else
-    Serial pc(USBTX, USBRX);
-    while (1)
-    {
-        pc.printf("*** CODAL PANIC : [%.3d]\n", statusCode);
-        wait_ms(500);
     }
 #endif
 }

--- a/target.json
+++ b/target.json
@@ -8,7 +8,6 @@
     "generate_hex":true,
     "config":{
         "CODAL_TIMESTAMP":"uint64_t",
-        "CODAL_CPU_CLOCK_SPEED":48000000,
         "USB_MAX_PKT_SIZE": 64,
         "DEVICE_USB_ENDPOINTS":8,
         "USB_DEFAULT_PID":"0x2402",

--- a/target.json
+++ b/target.json
@@ -8,6 +8,7 @@
     "generate_hex":true,
     "config":{
         "CODAL_TIMESTAMP":"uint64_t",
+        "CODAL_CPU_CLOCK_SPEED":48000000,
         "USB_MAX_PKT_SIZE": 64,
         "DEVICE_USB_ENDPOINTS":8,
         "USB_DEFAULT_PID":"0x2402",


### PR DESCRIPTION
The generic wait_ms, offered by the codal system timer, is not tight enough to perform small waits accurately. For instance, the sync call in the timer takes 4us alone to read the counter value and update the timestamp. This commit introduces an instruction based wait, using the clock speed of the CPU.